### PR TITLE
Maybe a solution for easier explicit type conversion?

### DIFF
--- a/lib/TIIndex.h
+++ b/lib/TIIndex.h
@@ -103,6 +103,12 @@ public:
   }
 };
 
+template <typename res_type, typename input_ty>
+res_type type_conv (const input_ty &I) {
+  return res_type(IDX_STORAGE_TY(I));
+}
+
+
 
 #define declare_free_index(tyname) struct tyname : free_index<tyname> { explicit tyname (IDX_STORAGE_TY d) : free_index(d) {}}; \
 tyname operator "" _ ## tyname (unsigned long long value){ \


### PR DESCRIPTION
This solution would allow you to do for instance

```c++
declare_free_index(ty1);
declare_free_index(ty2);

ty1 my_idx1(0);
ty2 my_idx2(4);
my_idx1 = type_conv<ty1>(my_idx2);
```